### PR TITLE
Add `accumulate` Function in Zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -15,6 +15,7 @@ pub fn build(b: *std.Build) void {
         TestFile{ .path = "src/tests/max_element_test.zig" },
         TestFile{ .path = "src/tests/any_of_test.zig" },
         TestFile{ .path = "src/tests/binary_search_test.zig" },
+        TestFile{ .path = "src/tests/accumulate_test.zig" },
     };
 
     setupTestStep(b, &tests);

--- a/src/algorithms/accumulate.zig
+++ b/src/algorithms/accumulate.zig
@@ -1,0 +1,25 @@
+/// Accumulates values in a range by repeatedly applying a binary
+/// operation. This allows you to reduce a range to a single value.
+///
+/// - `T` must be a compile time known type. This allows the fn to work
+///   on any type that supports the binary operation.
+///
+/// - `BinaryOp` must be a compile time known function that takes two
+///   parameters of type `T` and returns a `T`. This allows customizing
+///   the accumulation operation.
+///
+/// - `range` is the slice to accumulate over.
+///
+/// - `initial` is the starting value to begin accumulation from.
+///
+/// Accumulates by looping over `range`, applying `BinaryOp` to each
+/// element and the accumulator `acc`. Returns the final result.
+///
+/// Useful for sums, products, min/max, etc.
+pub fn accumulate(comptime T: type, comptime BinaryOp: fn (T, T) T, range: []const T, initial: T) T {
+    var acc = initial;
+    for (range) |item| {
+        acc = BinaryOp(acc, item);
+    }
+    return acc;
+}

--- a/src/tests/accumulate_test.zig
+++ b/src/tests/accumulate_test.zig
@@ -1,0 +1,28 @@
+const std = @import("std");
+const accumulate = @import("zigonic").accumulate;
+
+pub fn add(a: u32, b: u32) u32 {
+    return a + b;
+}
+
+pub fn multiply(a: f32, b: f32) f32 {
+    return a * b;
+}
+
+test "accumulate sum" {
+    const numbers = [_]u32{ 1, 2, 3, 4, 5 };
+    const result = accumulate(u32, add, numbers[0..], 0);
+    try std.testing.expectEqual(result, 15);
+}
+
+test "accumulate product" {
+    const numbers = [_]f32{ 1.0, 2.0, 3.0, 4.0, 5.0 };
+    const result = accumulate(f32, multiply, numbers[0..], 1.0);
+    try std.testing.expectEqual(result, 120.0);
+}
+
+test "accumulate empty range" {
+    const numbers = [_]u32{};
+    const result = accumulate(u32, add, numbers[0..], 0);
+    try std.testing.expectEqual(result, 0);
+}

--- a/src/zigonic.zig
+++ b/src/zigonic.zig
@@ -2,3 +2,4 @@ pub const allOf = @import("algorithms//all_of.zig").allOf;
 pub const anyOf = @import("algorithms//any_of.zig").anyOf;
 pub const maxElement = @import("algorithms//max_element.zig").maxElement;
 pub const binarySearch = @import("algorithms//binary_search.zig").binarySearch;
+pub const accumulate = @import("algorithms//accumulate.zig").accumulate;


### PR DESCRIPTION
Introduced the `accumulate` function in Zig, which applies a binary operation to a range of values. Also added tests for various types and operations.